### PR TITLE
chore: enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      pip-deps:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions-deps:
+        patterns: ["*"]

--- a/src/alchemia/synthesize.py
+++ b/src/alchemia/synthesize.py
@@ -13,8 +13,14 @@ from alchemia.aesthetic import format_prompt_injection, load_taste, resolve_aest
 
 # Canonical organ metadata for synthesis — names and domains for creative briefs
 _ORGAN_NAMES = {
-    "I": "Theoria", "II": "Poiesis", "III": "Ergon", "IV": "Taxis",
-    "V": "Logos", "VI": "Koinonia", "VII": "Kerygma", "META": "Meta-Organvm",
+    "I": "Theoria",
+    "II": "Poiesis",
+    "III": "Ergon",
+    "IV": "Taxis",
+    "V": "Logos",
+    "VI": "Koinonia",
+    "VII": "Kerygma",
+    "META": "Meta-Organvm",
 }
 _ORGAN_DOMAINS = {
     "I": "Theory, epistemology, recursion, ontology",
@@ -41,7 +47,8 @@ try:
 except ImportError:
     ORGAN_MAP = {
         f"ORGAN-{k}" if k != "META" else "META-ORGANVM": {
-            "name": _ORGAN_NAMES[k], "domain": _ORGAN_DOMAINS[k],
+            "name": _ORGAN_NAMES[k],
+            "domain": _ORGAN_DOMAINS[k],
         }
         for k in _ORGAN_NAMES
     }


### PR DESCRIPTION
Fleet-wide freshness rollout: weekly grouped version updates for all detected ecosystems (pip gha), capped at 3 open PRs per ecosystem. Vulnerability alerts and automated security fixes enabled alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)