### PR TITLE
feat(bifrons): GitHub star intake — sync corpus + provenance dossiers (Epics 1–2)

### DIFF
--- a/src/alchemia/channels/github_stars.py
+++ b/src/alchemia/channels/github_stars.py
@@ -26,10 +26,12 @@ def as_references(stars: list[dict]) -> list[dict]:
     """
     refs = []
     for star in stars:
-        refs.append({
-            "type": "url",
-            "source": star.get("url", ""),
-            "tags": ["github-star", star.get("primary_language", "").lower() or "repo"],
-            "notes": star.get("description", ""),
-        })
+        refs.append(
+            {
+                "type": "url",
+                "source": star.get("url", ""),
+                "tags": ["github-star", star.get("primary_language", "").lower() or "repo"],
+                "notes": star.get("description", ""),
+            },
+        )
     return refs

--- a/src/alchemia/channels/github_stars.py
+++ b/src/alchemia/channels/github_stars.py
@@ -1,0 +1,35 @@
+"""GitHub stars capture channel — the inbound source for BIFRONS.
+
+Follows the same shape as the other alchemia channels (bookmarks, apple_notes,
+...): a plain function returning ``list[dict]``. Here each dict is a starred
+repository. Unlike the aesthetic channels, stars are absorbed into the portal
+store (dossiers + resonance) rather than only appended to ``taste.yaml``; the
+optional ``as_references`` helper still records a shallow aesthetic signal for
+repos whose interest is primarily stylistic.
+"""
+
+from __future__ import annotations
+
+from alchemia.github.sync import enumerate_stars
+
+
+def sync_github_stars() -> list[dict]:
+    """Enumerate the authenticated user's starred repositories as dicts."""
+    return [repo.to_dict() for repo in enumerate_stars()]
+
+
+def as_references(stars: list[dict]) -> list[dict]:
+    """Project stars into shallow aesthetic references (S0 signal only).
+
+    Repo *intelligence* belongs in dossiers, not taste.yaml — this only
+    surfaces the star as a narrative/aesthetic breadcrumb.
+    """
+    refs = []
+    for star in stars:
+        refs.append({
+            "type": "url",
+            "source": star.get("url", ""),
+            "tags": ["github-star", star.get("primary_language", "").lower() or "repo"],
+            "notes": star.get("description", ""),
+        })
+    return refs

--- a/src/alchemia/cli.py
+++ b/src/alchemia/cli.py
@@ -414,8 +414,10 @@ def cmd_stars_sync(args):
     print(f"  login={s['login']}  total={s['total']}")
     print(f"  new={s['new']}  refreshed={s['refreshed']}  unstarred={s['unstarred']}")
     counts = storage.counts(conn)
-    print(f"  store: {counts['currently_starred']} currently starred, "
-          f"{counts['exchange']} exchanges, {counts['dossier']} dossiers")
+    print(
+        f"  store: {counts['currently_starred']} currently starred, "
+        f"{counts['exchange']} exchanges, {counts['dossier']} dossiers",
+    )
     conn.close()
 
 
@@ -430,8 +432,15 @@ def cmd_stars_status(args):
     print(f"  db: {args.db or storage.default_db_path()}")
     print(f"  last_sync: {storage.get_meta(conn, 'last_sync', 'never')}")
     print(f"  gh_login: {storage.get_meta(conn, 'gh_login', '—')}")
-    for key in ("external_repo", "currently_starred", "star_event",
-                "repo_snapshot", "artifact", "dossier", "exchange"):
+    for key in (
+        "external_repo",
+        "currently_starred",
+        "star_event",
+        "repo_snapshot",
+        "artifact",
+        "dossier",
+        "exchange",
+    ):
         print(f"  {key}: {counts.get(key, 0)}")
     conn.close()
 
@@ -461,8 +470,10 @@ def cmd_stars_dossier(args):
         result = materialize(conn, row["node_id"], MaterializationLevel.DOSSIER)
         status = result.get("status")
         if status == "materialized":
-            print(f"  {result['repo']}: ref={result['snapshot_ref'][:10]} "
-                  f"artifacts={result['artifacts']}")
+            print(
+                f"  {result['repo']}: ref={result['snapshot_ref'][:10]} "
+                f"artifacts={result['artifacts']}",
+            )
         else:
             print(f"  {row['full_name']}: {status}")
     conn.close()
@@ -609,16 +620,23 @@ def main():
 
     ps_doss = stars_sub.add_parser("dossier", help="Build S1 dossiers")
     ps_doss.add_argument("repo", nargs="?", help="owner/project (omit for --new batch)")
-    ps_doss.add_argument("--new", dest="new", action="store_true",
-                         help="Dossier the next batch of un-dossiered stars")
+    ps_doss.add_argument(
+        "--new",
+        dest="new",
+        action="store_true",
+        help="Dossier the next batch of un-dossiered stars",
+    )
     ps_doss.add_argument("--limit", type=int, default=25, help="Batch size for --new")
     ps_doss.add_argument("--db")
     ps_doss.set_defaults(func=cmd_stars_dossier)
 
     ps_mat = stars_sub.add_parser("materialize", help="Materialize one repo to a level")
     ps_mat.add_argument("repo", help="owner/project")
-    ps_mat.add_argument("--level", choices=["index", "dossier", "inspect", "contribute"],
-                        default="dossier")
+    ps_mat.add_argument(
+        "--level",
+        choices=["index", "dossier", "inspect", "contribute"],
+        default="dossier",
+    )
     ps_mat.add_argument("--db")
     ps_mat.set_defaults(func=cmd_stars_materialize)
 

--- a/src/alchemia/cli.py
+++ b/src/alchemia/cli.py
@@ -402,6 +402,97 @@ def cmd_gdocs_status(args):
         print("\n  Create a folder named 'Alchemia' in Google Drive to get started.")
 
 
+def cmd_stars_sync(args):
+    """Sync the GitHub star corpus into the BIFRONS portal store."""
+    from alchemia.github import storage
+    from alchemia.github.sync import sync_stars
+
+    conn = storage.connect(args.db)
+    print("STARS SYNC — enumerating starred repositories via gh...")
+    summary = sync_stars(conn)
+    s = summary.as_dict()
+    print(f"  login={s['login']}  total={s['total']}")
+    print(f"  new={s['new']}  refreshed={s['refreshed']}  unstarred={s['unstarred']}")
+    counts = storage.counts(conn)
+    print(f"  store: {counts['currently_starred']} currently starred, "
+          f"{counts['exchange']} exchanges, {counts['dossier']} dossiers")
+    conn.close()
+
+
+def cmd_stars_status(args):
+    """Show BIFRONS portal store status."""
+    from alchemia.github import storage
+
+    conn = storage.connect(args.db)
+    storage.init_intake_schema(conn)
+    counts = storage.counts(conn)
+    print("STARS STATUS —")
+    print(f"  db: {args.db or storage.default_db_path()}")
+    print(f"  last_sync: {storage.get_meta(conn, 'last_sync', 'never')}")
+    print(f"  gh_login: {storage.get_meta(conn, 'gh_login', '—')}")
+    for key in ("external_repo", "currently_starred", "star_event",
+                "repo_snapshot", "artifact", "dossier", "exchange"):
+        print(f"  {key}: {counts.get(key, 0)}")
+    conn.close()
+
+
+def cmd_stars_dossier(args):
+    """Build S1 dossiers — for one repo, or the next --new batch of stars."""
+    from alchemia.github import storage
+    from alchemia.github.materialize import materialize
+    from alchemia.github.models import MaterializationLevel
+
+    conn = storage.connect(args.db)
+    storage.init_intake_schema(conn)
+
+    targets = []
+    if args.repo:
+        row = storage.get_external_repo_by_full_name(conn, args.repo)
+        if row is None:
+            print(f"  {args.repo} not found — run 'alchemia stars sync' first.")
+            conn.close()
+            return
+        targets.append(row)
+    else:
+        targets = storage.repos_needing_dossier(conn, limit=args.limit)
+
+    print(f"STARS DOSSIER — building {len(targets)} S1 dossier(s)...")
+    for row in targets:
+        result = materialize(conn, row["node_id"], MaterializationLevel.DOSSIER)
+        status = result.get("status")
+        if status == "materialized":
+            print(f"  {result['repo']}: ref={result['snapshot_ref'][:10]} "
+                  f"artifacts={result['artifacts']}")
+        else:
+            print(f"  {row['full_name']}: {status}")
+    conn.close()
+
+
+def cmd_stars_materialize(args):
+    """Materialize one repo to a chosen level (index/dossier/inspect/contribute)."""
+    from alchemia.github import storage
+    from alchemia.github.materialize import materialize
+    from alchemia.github.models import MaterializationLevel
+
+    level_map = {
+        "index": MaterializationLevel.INDEX,
+        "dossier": MaterializationLevel.DOSSIER,
+        "inspect": MaterializationLevel.INSPECT,
+        "contribute": MaterializationLevel.CONTRIBUTE,
+    }
+    conn = storage.connect(args.db)
+    storage.init_intake_schema(conn)
+    row = storage.get_external_repo_by_full_name(conn, args.repo)
+    if row is None:
+        print(f"  {args.repo} not found — run 'alchemia stars sync' first.")
+        conn.close()
+        return
+    result = materialize(conn, row["node_id"], level_map[args.level])
+    for key, value in result.items():
+        print(f"  {key}: {value}")
+    conn.close()
+
+
 DEFAULT_SOURCE_DIRS = [
     "~/Workspace/intake",
     "~/Workspace/meta-organvm",
@@ -504,7 +595,38 @@ def main():
     p_gdstatus = sub.add_parser("gdocs-status", help="Show Google Docs integration status")
     p_gdstatus.set_defaults(func=cmd_gdocs_status)
 
+    # stars — BIFRONS GitHub star intake (inbound half of the portal)
+    p_stars = sub.add_parser("stars", help="BIFRONS: absorb the GitHub star corpus")
+    stars_sub = p_stars.add_subparsers(dest="stars_command")
+
+    ps_sync = stars_sub.add_parser("sync", help="Sync all starred repos into the portal store")
+    ps_sync.add_argument("--db", help="Portal DB path (default ~/.organvm/bifrons/portal.db)")
+    ps_sync.set_defaults(func=cmd_stars_sync)
+
+    ps_status = stars_sub.add_parser("status", help="Show portal store status")
+    ps_status.add_argument("--db")
+    ps_status.set_defaults(func=cmd_stars_status)
+
+    ps_doss = stars_sub.add_parser("dossier", help="Build S1 dossiers")
+    ps_doss.add_argument("repo", nargs="?", help="owner/project (omit for --new batch)")
+    ps_doss.add_argument("--new", dest="new", action="store_true",
+                         help="Dossier the next batch of un-dossiered stars")
+    ps_doss.add_argument("--limit", type=int, default=25, help="Batch size for --new")
+    ps_doss.add_argument("--db")
+    ps_doss.set_defaults(func=cmd_stars_dossier)
+
+    ps_mat = stars_sub.add_parser("materialize", help="Materialize one repo to a level")
+    ps_mat.add_argument("repo", help="owner/project")
+    ps_mat.add_argument("--level", choices=["index", "dossier", "inspect", "contribute"],
+                        default="dossier")
+    ps_mat.add_argument("--db")
+    ps_mat.set_defaults(func=cmd_stars_materialize)
+
     args = parser.parse_args()
+    # Nested subcommands: show help if a group was named without an action.
+    if args.command == "stars" and not getattr(args, "stars_command", None):
+        p_stars.print_help()
+        sys.exit(1)
     if not args.command:
         parser.print_help()
         sys.exit(1)

--- a/src/alchemia/github/__init__.py
+++ b/src/alchemia/github/__init__.py
@@ -1,0 +1,25 @@
+"""BIFRONS — the GitHub star-intake face of alchemia.
+
+The inbound half of the BIFRONS star<->contribution portal. Enumerates the
+owner's starred repositories, absorbs each into a provenance-backed dossier at
+metadata-first materialization levels (S0-S3), and persists everything into the
+shared portal store (``~/.organvm/bifrons/portal.db``) that the organvm-engine
+network/portal/contrib subsystems read downstream.
+
+Naming: BIFRONS (Janus, two-faced) is the star<->contribution portal and is
+deliberately distinct from IANVA (the MCP doorway/aggregator).
+"""
+
+from alchemia.github.models import (
+    Artifact,
+    Dossier,
+    MaterializationLevel,
+    StarredRepo,
+)
+
+__all__ = [
+    "Artifact",
+    "Dossier",
+    "MaterializationLevel",
+    "StarredRepo",
+]

--- a/src/alchemia/github/client.py
+++ b/src/alchemia/github/client.py
@@ -1,0 +1,124 @@
+"""Authenticated GitHub adapter for BIFRONS star intake.
+
+Thin wrapper over the ``gh`` CLI so the portal never has to manage tokens
+itself: ``gh`` already holds the authenticated session. This is the single
+integration seam the design calls for ("a dedicated authenticated user-stars
+adapter as its first integration seam").
+
+All calls are READ-ONLY. Nothing here mutates a repository, and nothing here
+executes code fetched from a starred repository — only metadata/JSON is read.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any
+
+# The star media type is required to obtain ``starred_at`` on each star; the
+# plain ``/user/starred`` response omits it.
+STAR_ACCEPT = "application/vnd.github.star+json"
+
+
+class GitHubError(RuntimeError):
+    """Raised when the gh CLI is missing, unauthenticated, or errors."""
+
+
+def gh_available() -> bool:
+    """True when the gh CLI is installed and reports an authenticated user."""
+    if shutil.which("gh") is None:
+        return False
+    try:
+        run_gh(["api", "user", "-q", ".login"])
+    except GitHubError:
+        return False
+    return True
+
+
+def run_gh(args: list[str], *, check: bool = True) -> str:
+    """Run ``gh`` with the given args and return stdout.
+
+    Raises GitHubError on a non-zero exit (unless ``check`` is False, in which
+    case stdout is returned as-is).
+    """
+    if shutil.which("gh") is None:
+        raise GitHubError("gh CLI not found on PATH")
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:  # pragma: no cover - environment failure
+        raise GitHubError(f"failed to invoke gh: {exc}") from exc
+    if check and result.returncode != 0:
+        raise GitHubError(
+            f"gh {' '.join(args)} exited {result.returncode}: {result.stderr.strip()}",
+        )
+    return result.stdout
+
+
+def gh_api(path: str, *, accept: str | None = None, jq: str | None = None) -> Any:
+    """GET a single GitHub API path and parse the JSON response.
+
+    Returns the parsed JSON (dict/list), or the raw string if ``jq`` is set.
+    """
+    args = ["api", path]
+    if accept:
+        args += ["-H", f"Accept: {accept}"]
+    if jq:
+        args += ["-q", jq]
+        return run_gh(args).strip()
+    out = run_gh(args)
+    return json.loads(out) if out.strip() else None
+
+
+def gh_api_paginated(path: str, *, accept: str | None = None) -> list[Any]:
+    """GET a paginated GitHub API path, concatenating every page.
+
+    ``gh api --paginate --slurp`` emits a single JSON array of all pages when
+    the endpoint returns arrays. We fall back to per-page concatenation if the
+    installed gh predates ``--slurp``.
+    """
+    args = ["api", "--paginate", "--slurp", path]
+    if accept:
+        args += ["-H", f"Accept: {accept}"]
+    try:
+        out = run_gh(args)
+        data = json.loads(out) if out.strip() else []
+    except GitHubError:
+        # Older gh without --slurp: paginate returns concatenated arrays which
+        # are not valid combined JSON. Read page-by-page instead.
+        return _paginate_manual(path, accept=accept)
+    # --slurp yields a list of pages (each a list) OR a flat list; normalize.
+    flat: list[Any] = []
+    for item in data:
+        if isinstance(item, list):
+            flat.extend(item)
+        else:
+            flat.append(item)
+    return flat
+
+
+def _paginate_manual(path: str, *, accept: str | None = None) -> list[Any]:
+    """Manual pagination fallback via the ``page`` query parameter."""
+    results: list[Any] = []
+    page = 1
+    joiner = "&" if "?" in path else "?"
+    while True:
+        page_path = f"{path}{joiner}per_page=100&page={page}"
+        chunk = gh_api(page_path, accept=accept)
+        if not chunk:
+            break
+        results.extend(chunk)
+        if len(chunk) < 100:
+            break
+        page += 1
+    return results
+
+
+def authenticated_login() -> str:
+    """Return the authenticated gh user's login (raises if unauthenticated)."""
+    return gh_api("user", jq=".login")

--- a/src/alchemia/github/dossier.py
+++ b/src/alchemia/github/dossier.py
@@ -22,9 +22,19 @@ DOSSIER_SCHEMA_VERSION = "1.0"
 
 # Manifests we probe for (presence only) to sketch the architecture cheaply.
 MANIFEST_FILES = [
-    "pyproject.toml", "setup.py", "requirements.txt", "package.json", "go.mod",
-    "Cargo.toml", "pom.xml", "build.gradle", "Gemfile", "composer.json",
-    "Dockerfile", "flake.nix", ".github/workflows",
+    "pyproject.toml",
+    "setup.py",
+    "requirements.txt",
+    "package.json",
+    "go.mod",
+    "Cargo.toml",
+    "pom.xml",
+    "build.gradle",
+    "Gemfile",
+    "composer.json",
+    "Dockerfile",
+    "flake.nix",
+    ".github/workflows",
 ]
 
 README_CANDIDATES = ["README.md", "README.rst", "README", "readme.md"]
@@ -188,8 +198,12 @@ def build_dossier(
         exchange = storage.exchange_for_repo(conn, repo.node_id)
         exchange_id = exchange["exchange_id"] if exchange else ""
         storage.insert_snapshot(
-            conn, node_id=repo.node_id, full_name=repo.full_name, ref=ref,
-            pushed_at=repo.pushed_at, stargazers_count=repo.stargazers_count,
+            conn,
+            node_id=repo.node_id,
+            full_name=repo.full_name,
+            ref=ref,
+            pushed_at=repo.pushed_at,
+            stargazers_count=repo.stargazers_count,
             open_issue_count=repo.open_issues_count,
         )
         for art in artifacts:

--- a/src/alchemia/github/dossier.py
+++ b/src/alchemia/github/dossier.py
@@ -1,0 +1,216 @@
+"""Dossier construction for BIFRONS — the S1 absorption product.
+
+Builds a versioned, provenance-backed intelligence record for one external
+repository from metadata only. Every dossier is pinned to an exact commit sha
+so the absorption is reproducible; every fetched artifact carries a sha256.
+
+We never clone the repository and never execute any of its code.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any
+
+from alchemia.github import storage
+from alchemia.github.client import GitHubError, gh_api
+from alchemia.github.licensing import discover_contracts
+from alchemia.github.models import Artifact, Dossier, MaterializationLevel, StarredRepo
+
+DOSSIER_SCHEMA_VERSION = "1.0"
+
+# Manifests we probe for (presence only) to sketch the architecture cheaply.
+MANIFEST_FILES = [
+    "pyproject.toml", "setup.py", "requirements.txt", "package.json", "go.mod",
+    "Cargo.toml", "pom.xml", "build.gradle", "Gemfile", "composer.json",
+    "Dockerfile", "flake.nix", ".github/workflows",
+]
+
+README_CANDIDATES = ["README.md", "README.rst", "README", "readme.md"]
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _resolve_ref(owner: str, name: str, branch: str) -> str:
+    """Pin the snapshot to the default branch's HEAD sha."""
+    try:
+        sha = gh_api(f"repos/{owner}/{name}/commits/{branch}", jq=".sha")
+        return sha or ""
+    except GitHubError:
+        return ""
+
+
+def _fetch_file(owner: str, name: str, path: str, ref: str) -> tuple[Artifact, bytes] | None:
+    """Fetch one file's content at ``ref``; return (Artifact, raw_bytes) or None."""
+    api_path = f"repos/{owner}/{name}/contents/{path}"
+    if ref:
+        api_path += f"?ref={ref}"
+    try:
+        obj = gh_api(api_path)
+    except GitHubError:
+        return None
+    if not isinstance(obj, dict) or obj.get("type") != "file":
+        return None
+    encoded = obj.get("content") or ""
+    try:
+        raw = base64.b64decode(encoded)
+    except (ValueError, TypeError):
+        raw = b""
+    art = Artifact(
+        kind=_artifact_kind(path),
+        name=path,
+        source_url=obj.get("html_url", ""),
+        ref=ref,
+        fetched_at=storage.now_iso(),
+        sha256=_sha256(raw),
+        bytes_len=len(raw),
+        truncated=bool(obj.get("size", 0) and not encoded),
+    )
+    return art, raw
+
+
+def _artifact_kind(path: str) -> str:
+    lower = path.lower()
+    if lower.startswith("readme"):
+        return "readme"
+    if lower.startswith("license"):
+        return "license"
+    if "contributing" in lower:
+        return "contributing"
+    if "security" in lower:
+        return "security"
+    return "manifest"
+
+
+def _probe_manifests(owner: str, name: str, ref: str) -> list[str]:
+    present: list[str] = []
+    for path in MANIFEST_FILES:
+        api_path = f"repos/{owner}/{name}/contents/{path}"
+        if ref:
+            api_path += f"?ref={ref}"
+        try:
+            sha = gh_api(api_path, jq=".sha")
+        except GitHubError:
+            sha = ""
+        if sha:
+            present.append(path)
+    return present
+
+
+def _languages(owner: str, name: str) -> dict[str, float]:
+    try:
+        raw = gh_api(f"repos/{owner}/{name}/languages")
+    except GitHubError:
+        return {}
+    if not isinstance(raw, dict) or not raw:
+        return {}
+    total = sum(raw.values()) or 1
+    return {lang: round(count / total, 3) for lang, count in raw.items()}
+
+
+def build_dossier(
+    repo: StarredRepo,
+    *,
+    conn: Any = None,
+    level: MaterializationLevel = MaterializationLevel.DOSSIER,
+) -> tuple[Dossier, list[Artifact]]:
+    """Build (and optionally persist) an S1 dossier for a starred repository.
+
+    If ``conn`` is provided, the dossier + artifacts are written to the portal
+    store and the repo's materialization level is advanced.
+    """
+    owner, name = repo.owner, repo.name
+    ref = _resolve_ref(owner, name, repo.default_branch)
+
+    artifacts: list[Artifact] = []
+    # README
+    for candidate in README_CANDIDATES:
+        fetched = _fetch_file(owner, name, candidate, ref)
+        if fetched:
+            artifacts.append(fetched[0])
+            break
+    # Contracts (license class + policy files)
+    contracts = discover_contracts(owner, name, spdx=repo.license_spdx)
+    for label in ("contributing", "security", "code_of_conduct"):
+        path = contracts.get(label)
+        if path:
+            fetched = _fetch_file(owner, name, path, ref)
+            if fetched:
+                artifacts.append(fetched[0])
+
+    manifests = _probe_manifests(owner, name, ref)
+    languages = _languages(owner, name) or (
+        {repo.primary_language: 1.0} if repo.primary_language else {}
+    )
+
+    dossier = Dossier(
+        schema_version=DOSSIER_SCHEMA_VERSION,
+        external_repo=repo.full_name,
+        github_node_id=repo.node_id,
+        level=level.value,
+        starred_at=repo.starred_at,
+        snapshot_ref=ref,
+        snapshot_at=storage.now_iso(),
+        identity={
+            "owner_type": repo.owner_type,
+            "description": repo.description,
+            "topics": repo.topics,
+            "primary_language": repo.primary_language,
+            "languages": languages,
+        },
+        state={
+            "archived": repo.archived,
+            "fork": repo.fork,
+            "default_branch": repo.default_branch,
+            "last_push_at": repo.pushed_at,
+            "stargazers_count": repo.stargazers_count,
+            "open_issue_count": repo.open_issues_count,
+        },
+        contracts=contracts,
+        architecture={
+            "manifests": manifests,
+            "test_strategy": _infer_test_strategy(manifests),
+            "deployment_model": "container" if "Dockerfile" in manifests else "",
+        },
+        provenance={
+            "captured_by": "alchemia.github-stars",
+            "source_url": repo.url,
+            "snapshot_ref": ref,
+            "artifacts": [a.name for a in artifacts],
+            "hashes": {a.name: a.sha256 for a in artifacts},
+        },
+    )
+
+    if conn is not None:
+        exchange = storage.exchange_for_repo(conn, repo.node_id)
+        exchange_id = exchange["exchange_id"] if exchange else ""
+        storage.insert_snapshot(
+            conn, node_id=repo.node_id, full_name=repo.full_name, ref=ref,
+            pushed_at=repo.pushed_at, stargazers_count=repo.stargazers_count,
+            open_issue_count=repo.open_issues_count,
+        )
+        for art in artifacts:
+            storage.insert_artifact(conn, repo.node_id, repo.full_name, art)
+        storage.upsert_dossier(conn, dossier, exchange_id=exchange_id)
+        storage.set_materialization_level(conn, repo.node_id, level.value)
+        conn.commit()
+
+    return dossier, artifacts
+
+
+def _infer_test_strategy(manifests: list[str]) -> list[str]:
+    strategy: list[str] = []
+    if "pyproject.toml" in manifests or "setup.py" in manifests:
+        strategy.append("python")
+    if "package.json" in manifests:
+        strategy.append("node")
+    if "go.mod" in manifests:
+        strategy.append("go")
+    if "Cargo.toml" in manifests:
+        strategy.append("rust")
+    if ".github/workflows" in manifests:
+        strategy.append("github-actions")
+    return strategy

--- a/src/alchemia/github/licensing.py
+++ b/src/alchemia/github/licensing.py
@@ -13,23 +13,57 @@ from __future__ import annotations
 from alchemia.github.client import GitHubError, gh_api
 
 # SPDX ids that permit code adaptation with attribution + provenance.
-PERMISSIVE_SPDX = frozenset({
-    "MIT", "MIT-0", "APACHE-2.0", "BSD-2-CLAUSE", "BSD-3-CLAUSE", "BSD-3-CLAUSE-CLEAR",
-    "ISC", "0BSD", "UNLICENSE", "ZLIB", "BSL-1.0", "PYTHON-2.0", "POSTGRESQL",
-    "CC0-1.0", "WTFPL", "NCSA",
-})
+PERMISSIVE_SPDX = frozenset(
+    {
+        "MIT",
+        "MIT-0",
+        "APACHE-2.0",
+        "BSD-2-CLAUSE",
+        "BSD-3-CLAUSE",
+        "BSD-3-CLAUSE-CLEAR",
+        "ISC",
+        "0BSD",
+        "UNLICENSE",
+        "ZLIB",
+        "BSL-1.0",
+        "PYTHON-2.0",
+        "POSTGRESQL",
+        "CC0-1.0",
+        "WTFPL",
+        "NCSA",
+    },
+)
 
 # SPDX ids whose obligations require explicit acceptance before code reuse.
-COPYLEFT_SPDX = frozenset({
-    "GPL-2.0", "GPL-3.0", "GPL-2.0-ONLY", "GPL-2.0-OR-LATER", "GPL-3.0-ONLY",
-    "GPL-3.0-OR-LATER", "AGPL-3.0", "AGPL-3.0-ONLY", "AGPL-3.0-OR-LATER",
-    "LGPL-2.1", "LGPL-3.0", "LGPL-2.1-ONLY", "LGPL-3.0-ONLY", "MPL-2.0",
-    "EPL-2.0", "CDDL-1.0", "OSL-3.0", "EUPL-1.2",
-})
+COPYLEFT_SPDX = frozenset(
+    {
+        "GPL-2.0",
+        "GPL-3.0",
+        "GPL-2.0-ONLY",
+        "GPL-2.0-OR-LATER",
+        "GPL-3.0-ONLY",
+        "GPL-3.0-OR-LATER",
+        "AGPL-3.0",
+        "AGPL-3.0-ONLY",
+        "AGPL-3.0-OR-LATER",
+        "LGPL-2.1",
+        "LGPL-3.0",
+        "LGPL-2.1-ONLY",
+        "LGPL-3.0-ONLY",
+        "MPL-2.0",
+        "EPL-2.0",
+        "CDDL-1.0",
+        "OSL-3.0",
+        "EUPL-1.2",
+    },
+)
 
 CONTRACT_FILES = {
     "contributing": [
-        "CONTRIBUTING.md", "CONTRIBUTING", ".github/CONTRIBUTING.md", "docs/CONTRIBUTING.md",
+        "CONTRIBUTING.md",
+        "CONTRIBUTING",
+        ".github/CONTRIBUTING.md",
+        "docs/CONTRIBUTING.md",
     ],
     "security": ["SECURITY.md", ".github/SECURITY.md"],
     "code_of_conduct": ["CODE_OF_CONDUCT.md", ".github/CODE_OF_CONDUCT.md"],

--- a/src/alchemia/github/licensing.py
+++ b/src/alchemia/github/licensing.py
@@ -1,0 +1,120 @@
+"""License firewall + contribution-contract discovery for BIFRONS.
+
+The portal must distinguish what it may legally do with a starred repository
+before any code adaptation. This module classifies the license and discovers
+contribution contracts (CONTRIBUTING/SECURITY/CoC/CLA-DCO), producing the
+inputs the engine's inbound transmutation step consults.
+
+READ-ONLY: everything here reads metadata via gh; nothing is cloned or run.
+"""
+
+from __future__ import annotations
+
+from alchemia.github.client import GitHubError, gh_api
+
+# SPDX ids that permit code adaptation with attribution + provenance.
+PERMISSIVE_SPDX = frozenset({
+    "MIT", "MIT-0", "APACHE-2.0", "BSD-2-CLAUSE", "BSD-3-CLAUSE", "BSD-3-CLAUSE-CLEAR",
+    "ISC", "0BSD", "UNLICENSE", "ZLIB", "BSL-1.0", "PYTHON-2.0", "POSTGRESQL",
+    "CC0-1.0", "WTFPL", "NCSA",
+})
+
+# SPDX ids whose obligations require explicit acceptance before code reuse.
+COPYLEFT_SPDX = frozenset({
+    "GPL-2.0", "GPL-3.0", "GPL-2.0-ONLY", "GPL-2.0-OR-LATER", "GPL-3.0-ONLY",
+    "GPL-3.0-OR-LATER", "AGPL-3.0", "AGPL-3.0-ONLY", "AGPL-3.0-OR-LATER",
+    "LGPL-2.1", "LGPL-3.0", "LGPL-2.1-ONLY", "LGPL-3.0-ONLY", "MPL-2.0",
+    "EPL-2.0", "CDDL-1.0", "OSL-3.0", "EUPL-1.2",
+})
+
+CONTRACT_FILES = {
+    "contributing": [
+        "CONTRIBUTING.md", "CONTRIBUTING", ".github/CONTRIBUTING.md", "docs/CONTRIBUTING.md",
+    ],
+    "security": ["SECURITY.md", ".github/SECURITY.md"],
+    "code_of_conduct": ["CODE_OF_CONDUCT.md", ".github/CODE_OF_CONDUCT.md"],
+    "pr_template": [".github/pull_request_template.md", ".github/PULL_REQUEST_TEMPLATE.md"],
+}
+
+# Default behavior permitted per license class (the firewall).
+LICENSE_DECISION = {
+    "permissive": "code-adaptation-with-attribution",
+    "copyleft": "idea-or-interface-only-unless-obligations-accepted",
+    "none": "no-code-or-asset-copying",
+    "unknown": "no-code-or-asset-copying",
+}
+
+
+def classify_license(spdx: str) -> str:
+    """Return 'permissive' | 'copyleft' | 'none' | 'unknown' for an SPDX id."""
+    if not spdx or spdx.upper() in {"NOASSERTION", "NONE"}:
+        return "none" if spdx else "unknown"
+    key = spdx.upper()
+    if key in PERMISSIVE_SPDX:
+        return "permissive"
+    if key in COPYLEFT_SPDX:
+        return "copyleft"
+    return "unknown"
+
+
+def license_decision(license_class: str) -> str:
+    """Map a license class to its permitted default behavior."""
+    return LICENSE_DECISION.get(license_class, LICENSE_DECISION["unknown"])
+
+
+def _path_exists(owner: str, name: str, path: str) -> bool:
+    try:
+        result = gh_api(f"repos/{owner}/{name}/contents/{path}", jq=".sha")
+    except GitHubError:
+        return False
+    return bool(result)
+
+
+def discover_contracts(owner: str, name: str, *, spdx: str = "") -> dict:
+    """Discover license class + contribution contracts for a repository.
+
+    ``spdx`` may be supplied from the already-known star metadata to skip a
+    call; otherwise the license endpoint is queried.
+    """
+    resolved_spdx = spdx
+    if not resolved_spdx:
+        try:
+            resolved_spdx = gh_api(f"repos/{owner}/{name}/license", jq=".license.spdx_id") or ""
+        except GitHubError:
+            resolved_spdx = ""
+
+    license_class = classify_license(resolved_spdx)
+    contracts: dict = {
+        "license": {"spdx": resolved_spdx, "class": license_class},
+        "decision": license_decision(license_class),
+        "cla_or_dco": "unknown",
+    }
+    for label, candidates in CONTRACT_FILES.items():
+        found = next((c for c in candidates if _path_exists(owner, name, c)), "")
+        contracts[label] = found
+
+    # DCO is commonly signalled by a "Signed-off-by" requirement in CONTRIBUTING.
+    if contracts.get("contributing"):
+        contracts["cla_or_dco"] = _detect_dco_cla(owner, name, contracts["contributing"])
+    return contracts
+
+
+def _detect_dco_cla(owner: str, name: str, path: str) -> str:
+    """Best-effort DCO/CLA detection from the CONTRIBUTING file text."""
+    try:
+        text = gh_api(f"repos/{owner}/{name}/contents/{path}", jq=".content") or ""
+    except GitHubError:
+        return "unknown"
+    if not text:
+        return "unknown"
+    import base64
+
+    try:
+        decoded = base64.b64decode(text).decode("utf-8", "ignore").lower()
+    except (ValueError, UnicodeDecodeError):
+        return "unknown"
+    if "signed-off-by" in decoded or "developer certificate of origin" in decoded:
+        return "dco"
+    if "contributor license agreement" in decoded or "cla" in decoded:
+        return "cla"
+    return "none"

--- a/src/alchemia/github/materialize.py
+++ b/src/alchemia/github/materialize.py
@@ -1,0 +1,119 @@
+"""Materialization-level orchestration for BIFRONS.
+
+Absorb a starred repository only as deeply as its resonance warrants:
+
+* S0 INDEX      — identity/metadata (produced by ``sync``)
+* S1 DOSSIER    — README/license/manifests/contracts/health (``dossier``)
+* S2 INSPECT    — + a metadata-only source tree + notable modules
+* S3 CONTRIBUTE — ephemeral fork/worktree/test env — deferred to the engine's
+                  contribution pipeline (never performed here)
+
+This keeps thousands of stars computationally manageable and prevents untrusted
+repositories from becoming permanent local dependencies. No repository is ever
+cloned wholesale and no fetched code is ever executed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from alchemia.github import storage
+from alchemia.github.client import GitHubError, gh_api
+from alchemia.github.dossier import build_dossier
+from alchemia.github.models import MaterializationLevel, StarredRepo
+
+# Cap on tree entries recorded at S2 (paths only — never content).
+S2_TREE_CAP = 4000
+
+
+def _row_to_repo(row: sqlite3.Row) -> StarredRepo:
+    import json
+
+    return StarredRepo(
+        full_name=row["full_name"],
+        node_id=row["node_id"],
+        owner=row["owner"],
+        name=row["name"],
+        url=row["url"],
+        starred_at=row["first_starred_at"],
+        description=row["description"],
+        topics=json.loads(row["topics"] or "[]"),
+        primary_language=row["primary_language"],
+        owner_type=row["owner_type"],
+        default_branch=row["default_branch"],
+        archived=bool(row["archived"]),
+        fork=bool(row["fork"]),
+        is_private=bool(row["is_private"]),
+        license_spdx=row["license_spdx"],
+    )
+
+
+def materialize(
+    conn: sqlite3.Connection,
+    node_id: str,
+    level: MaterializationLevel,
+) -> dict:
+    """Materialize one external repo up to ``level``. Returns a result summary."""
+    row = storage.get_external_repo(conn, node_id)
+    if row is None:
+        return {"status": "unknown-repo", "node_id": node_id}
+    repo = _row_to_repo(row)
+
+    if repo.is_private:
+        # Private-star metadata stays local and minimal; do not deep-materialize.
+        return {"status": "private-skip", "repo": repo.full_name, "level": "S0"}
+
+    if level == MaterializationLevel.INDEX:
+        storage.set_materialization_level(conn, node_id, "S0")
+        conn.commit()
+        return {"status": "indexed", "repo": repo.full_name, "level": "S0"}
+
+    if level == MaterializationLevel.CONTRIBUTE:
+        # S3 is an engine-owned action (ephemeral fork/worktree/test env).
+        return {
+            "status": "deferred-to-engine",
+            "repo": repo.full_name,
+            "level": "S3",
+            "reason": "S3 contribution workspace is created by organvm-engine contrib",
+        }
+
+    # S1 / S2 both build the dossier; S2 additionally records the source tree.
+    dossier, artifacts = build_dossier(repo, conn=conn, level=level)
+    result = {
+        "status": "materialized",
+        "repo": repo.full_name,
+        "level": level.value,
+        "snapshot_ref": dossier.snapshot_ref,
+        "artifacts": len(artifacts),
+    }
+    if level == MaterializationLevel.INSPECT:
+        tree = _fetch_tree(repo.owner, repo.name, dossier.snapshot_ref)
+        result["tree_entries"] = len(tree)
+        result["notable_modules"] = _notable_modules(tree)
+    return result
+
+
+def _fetch_tree(owner: str, name: str, ref: str) -> list[str]:
+    """Fetch the repo tree (paths only) at ref. Metadata, never file content."""
+    if not ref:
+        return []
+    try:
+        obj = gh_api(f"repos/{owner}/{name}/git/trees/{ref}?recursive=1")
+    except GitHubError:
+        return []
+    if not isinstance(obj, dict):
+        return []
+    entries = [e.get("path", "") for e in obj.get("tree", []) if e.get("type") == "blob"]
+    return entries[:S2_TREE_CAP]
+
+
+def _notable_modules(tree: list[str]) -> list[str]:
+    """Heuristic: top-level source dirs that look like modules/packages."""
+    tops: dict[str, int] = {}
+    for path in tree:
+        head = path.split("/", 1)[0]
+        if head in {".github", "docs", "tests", "test", "examples", "vendor"}:
+            continue
+        tops[head] = tops.get(head, 0) + 1
+    ranked = sorted(tops.items(), key=lambda kv: kv[1], reverse=True)
+    return [name for name, _ in ranked[:12]]

--- a/src/alchemia/github/models.py
+++ b/src/alchemia/github/models.py
@@ -18,9 +18,9 @@ class MaterializationLevel(str, Enum):
     escalate the level only for high-resonance / contribution candidates.
     """
 
-    INDEX = "S0"      # id/name/url/owner/description/topics/timestamps
-    DOSSIER = "S1"    # + README/license/manifests/contribution files/health
-    INSPECT = "S2"    # + selected source tree / architecture / dependency graph
+    INDEX = "S0"  # id/name/url/owner/description/topics/timestamps
+    DOSSIER = "S1"  # + README/license/manifests/contribution files/health
+    INSPECT = "S2"  # + selected source tree / architecture / dependency graph
     CONTRIBUTE = "S3"  # + ephemeral fork/worktree/test env (engine-owned)
 
     @property

--- a/src/alchemia/github/models.py
+++ b/src/alchemia/github/models.py
@@ -1,0 +1,136 @@
+"""Domain models for BIFRONS star intake.
+
+These are plain dataclasses with dict (de)serialization so they round-trip
+cleanly into SQLite/JSON/YAML without pulling in a dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class MaterializationLevel(str, Enum):
+    """How deeply a starred repository has been absorbed.
+
+    Metadata-first by design: we never clone every starred repository, and we
+    escalate the level only for high-resonance / contribution candidates.
+    """
+
+    INDEX = "S0"      # id/name/url/owner/description/topics/timestamps
+    DOSSIER = "S1"    # + README/license/manifests/contribution files/health
+    INSPECT = "S2"    # + selected source tree / architecture / dependency graph
+    CONTRIBUTE = "S3"  # + ephemeral fork/worktree/test env (engine-owned)
+
+    @property
+    def rank(self) -> int:
+        return {"S0": 0, "S1": 1, "S2": 2, "S3": 3}[self.value]
+
+
+@dataclass
+class StarredRepo:
+    """A single starred repository, as enumerated from the GitHub API.
+
+    ``node_id`` is the stable GitHub global node id (``R_...``); it is the
+    durable identity that survives renames, unlike ``full_name``.
+    """
+
+    full_name: str
+    node_id: str
+    owner: str
+    name: str
+    url: str
+    starred_at: str = ""
+    description: str = ""
+    topics: list[str] = field(default_factory=list)
+    primary_language: str = ""
+    owner_type: str = ""
+    default_branch: str = "main"
+    archived: bool = False
+    fork: bool = False
+    is_private: bool = False
+    pushed_at: str = ""
+    stargazers_count: int = 0
+    open_issues_count: int = 0
+    license_spdx: str = ""
+
+    @classmethod
+    def from_star_json(cls, obj: dict[str, Any]) -> StarredRepo:
+        """Build from a ``/user/starred`` element.
+
+        With the star media type each element is ``{starred_at, repo}``; without
+        it, each element is the repo object directly.
+        """
+        starred_at = ""
+        repo = obj
+        if "repo" in obj and isinstance(obj["repo"], dict):
+            starred_at = obj.get("starred_at", "")
+            repo = obj["repo"]
+        owner = repo.get("owner") or {}
+        lic = repo.get("license") or {}
+        return cls(
+            full_name=repo.get("full_name", ""),
+            node_id=repo.get("node_id", ""),
+            owner=owner.get("login", ""),
+            name=repo.get("name", ""),
+            url=repo.get("html_url", ""),
+            starred_at=starred_at,
+            description=repo.get("description") or "",
+            topics=list(repo.get("topics") or []),
+            primary_language=repo.get("language") or "",
+            owner_type=owner.get("type", ""),
+            default_branch=repo.get("default_branch", "main"),
+            archived=bool(repo.get("archived", False)),
+            fork=bool(repo.get("fork", False)),
+            is_private=bool(repo.get("private", False)),
+            pushed_at=repo.get("pushed_at") or "",
+            stargazers_count=int(repo.get("stargazers_count") or 0),
+            open_issues_count=int(repo.get("open_issues_count") or 0),
+            license_spdx=(lic.get("spdx_id") or "") if lic else "",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Artifact:
+    """A single absorbed artifact (README, license, manifest, policy file...).
+
+    Every artifact is pinned: ``source_url`` + ``ref`` + ``sha256`` make the
+    absorption reproducible and tamper-evident.
+    """
+
+    kind: str
+    name: str
+    source_url: str
+    ref: str
+    fetched_at: str
+    sha256: str
+    bytes_len: int = 0
+    truncated: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Dossier:
+    """A versioned intelligence record for one external repository."""
+
+    schema_version: str
+    external_repo: str
+    github_node_id: str
+    level: str
+    starred_at: str
+    snapshot_ref: str
+    snapshot_at: str
+    identity: dict[str, Any] = field(default_factory=dict)
+    state: dict[str, Any] = field(default_factory=dict)
+    contracts: dict[str, Any] = field(default_factory=dict)
+    architecture: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/alchemia/github/storage.py
+++ b/src/alchemia/github/storage.py
@@ -351,7 +351,7 @@ def insert_snapshot(
         (node_id, full_name, ref, now_iso(), pushed_at, stargazers_count,
          open_issue_count, state_json),
     )
-    return int(cur.lastrowid)
+    return int(cur.lastrowid or 0)
 
 
 def insert_artifact(conn: sqlite3.Connection, node_id: str, full_name: str, art: Any) -> None:

--- a/src/alchemia/github/storage.py
+++ b/src/alchemia/github/storage.py
@@ -1,0 +1,413 @@
+"""Persistent operational store for the BIFRONS portal.
+
+A single local SQLite file (``~/.organvm/bifrons/portal.db``, override with
+``$BIFRONS_DB``) is the portal's operational store. It is local, transactional,
+portable, and needs no service — sufficient for several thousand repositories.
+
+Table ownership (each repo owns its group's DDL; all ``CREATE ... IF NOT
+EXISTS`` so they compose idempotently on the same file):
+
+* alchemia (this module)  : bifrons_meta, external_repo, star_event,
+                            repo_snapshot, artifact, dossier, exchange
+* organvm-engine          : resonance_edge, transmutation_proposal,
+                            contribution_candidate, upstream_interaction,
+                            backflow_signal (+ the same ``exchange`` DDL so it
+                            can run standalone)
+
+The ``exchange`` table is the spine: one row per star traversal, seeded here at
+intake (state STARRED/INDEXED) and advanced by the engine downstream. Its DDL
+MUST stay byte-identical to the engine's copy — keep it minimal.
+
+Privacy: private-star metadata lives only in this local store and is never
+serialized into a public repository.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1.0"
+
+# --- shared spine DDL (MUST match organvm-engine's copy verbatim) ------------
+EXCHANGE_DDL = """
+CREATE TABLE IF NOT EXISTS exchange (
+    exchange_id            TEXT PRIMARY KEY,
+    external_repo_node_id  TEXT NOT NULL,
+    external_repo          TEXT NOT NULL,
+    state                  TEXT NOT NULL,
+    created_at             TEXT NOT NULL,
+    updated_at             TEXT NOT NULL,
+    data_json              TEXT NOT NULL DEFAULT '{}'
+)
+"""
+
+# --- alchemia-owned intake DDL ----------------------------------------------
+_INTAKE_DDL = [
+    """
+    CREATE TABLE IF NOT EXISTS bifrons_meta (
+        key   TEXT PRIMARY KEY,
+        value TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS external_repo (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        node_id               TEXT UNIQUE NOT NULL,
+        full_name             TEXT NOT NULL,
+        owner                 TEXT NOT NULL,
+        name                  TEXT NOT NULL,
+        url                   TEXT NOT NULL,
+        owner_type            TEXT DEFAULT '',
+        description           TEXT DEFAULT '',
+        topics                TEXT DEFAULT '[]',
+        primary_language      TEXT DEFAULT '',
+        default_branch        TEXT DEFAULT 'main',
+        archived              INTEGER DEFAULT 0,
+        fork                  INTEGER DEFAULT 0,
+        is_private            INTEGER DEFAULT 0,
+        license_spdx          TEXT DEFAULT '',
+        first_starred_at      TEXT DEFAULT '',
+        currently_starred     INTEGER DEFAULT 1,
+        materialization_level TEXT DEFAULT 'S0',
+        first_seen_at         TEXT DEFAULT '',
+        last_seen_at          TEXT DEFAULT ''
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS star_event (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        node_id          TEXT NOT NULL,
+        full_name        TEXT NOT NULL,
+        event            TEXT NOT NULL,
+        at               TEXT NOT NULL,
+        exchange_id      TEXT DEFAULT ''
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS repo_snapshot (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        node_id          TEXT NOT NULL,
+        full_name        TEXT NOT NULL,
+        ref              TEXT NOT NULL,
+        snapshot_at      TEXT NOT NULL,
+        pushed_at        TEXT DEFAULT '',
+        stargazers_count INTEGER DEFAULT 0,
+        open_issue_count INTEGER DEFAULT 0,
+        state_json       TEXT DEFAULT '{}'
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS artifact (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        node_id       TEXT NOT NULL,
+        full_name     TEXT NOT NULL,
+        kind          TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        source_url    TEXT DEFAULT '',
+        ref           TEXT DEFAULT '',
+        fetched_at    TEXT NOT NULL,
+        sha256        TEXT NOT NULL,
+        bytes_len     INTEGER DEFAULT 0,
+        truncated     INTEGER DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS dossier (
+        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        node_id        TEXT NOT NULL,
+        full_name      TEXT NOT NULL,
+        level          TEXT NOT NULL,
+        schema_version TEXT NOT NULL,
+        snapshot_ref   TEXT DEFAULT '',
+        snapshot_at    TEXT DEFAULT '',
+        doc_json       TEXT NOT NULL,
+        exchange_id    TEXT DEFAULT '',
+        UNIQUE(node_id, level)
+    )
+    """,
+]
+
+
+def now_iso() -> str:
+    """UTC ISO-8601 timestamp (seconds precision, Z-suffixed)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def default_db_path() -> Path:
+    """Resolve the portal DB path (``$BIFRONS_DB`` overrides the default)."""
+    env = os.environ.get("BIFRONS_DB")
+    if env:
+        return Path(env).expanduser()
+    return Path("~/.organvm/bifrons/portal.db").expanduser()
+
+
+def new_exchange_id() -> str:
+    """Mint a time-sortable exchange id (``ex_<ms-hex><rand-hex>``)."""
+    ms = int(time.time() * 1000)
+    return f"ex_{ms:012x}{os.urandom(4).hex()}"
+
+
+def connect(path: Path | str | None = None) -> sqlite3.Connection:
+    """Open (creating parent dirs) the portal DB in WAL mode."""
+    db_path = Path(path).expanduser() if path else default_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def init_intake_schema(conn: sqlite3.Connection) -> None:
+    """Create the alchemia-owned intake tables + the shared exchange spine."""
+    for ddl in _INTAKE_DDL:
+        conn.execute(ddl)
+    conn.execute(EXCHANGE_DDL)
+    set_meta(conn, "schema_version", SCHEMA_VERSION)
+    conn.commit()
+
+
+# --- meta --------------------------------------------------------------------
+def set_meta(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        "INSERT INTO bifrons_meta(key, value) VALUES(?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        (key, value),
+    )
+
+
+def get_meta(conn: sqlite3.Connection, key: str, default: str = "") -> str:
+    row = conn.execute("SELECT value FROM bifrons_meta WHERE key=?", (key,)).fetchone()
+    return row["value"] if row else default
+
+
+# --- external_repo -----------------------------------------------------------
+def get_external_repo(conn: sqlite3.Connection, node_id: str) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM external_repo WHERE node_id=?",
+        (node_id,),
+    ).fetchone()
+
+
+def get_external_repo_by_full_name(
+    conn: sqlite3.Connection,
+    full_name: str,
+) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM external_repo WHERE full_name=?",
+        (full_name,),
+    ).fetchone()
+
+
+def repos_needing_dossier(
+    conn: sqlite3.Connection,
+    *,
+    limit: int | None = None,
+) -> list[sqlite3.Row]:
+    """Currently-starred public repos still at S0 (no dossier yet)."""
+    sql = (
+        "SELECT * FROM external_repo WHERE currently_starred=1 "
+        "AND is_private=0 AND materialization_level='S0' ORDER BY full_name"
+    )
+    if limit:
+        sql += f" LIMIT {int(limit)}"
+    return conn.execute(sql).fetchall()
+
+
+def upsert_external_repo(conn: sqlite3.Connection, repo: Any, *, seen_at: str) -> bool:
+    """Insert or update an external_repo row. Returns True if it was new."""
+    import json
+
+    existing = get_external_repo(conn, repo.node_id)
+    if existing is None:
+        conn.execute(
+            """
+            INSERT INTO external_repo(
+                node_id, full_name, owner, name, url, owner_type, description,
+                topics, primary_language, default_branch, archived, fork,
+                is_private, license_spdx, first_starred_at, currently_starred,
+                materialization_level, first_seen_at, last_seen_at)
+            VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1,'S0',?,?)
+            """,
+            (
+                repo.node_id, repo.full_name, repo.owner, repo.name, repo.url,
+                repo.owner_type, repo.description, json.dumps(repo.topics),
+                repo.primary_language, repo.default_branch, int(repo.archived),
+                int(repo.fork), int(repo.is_private), repo.license_spdx,
+                repo.starred_at, seen_at, seen_at,
+            ),
+        )
+        return True
+    conn.execute(
+        """
+        UPDATE external_repo SET
+            full_name=?, owner=?, name=?, url=?, owner_type=?, description=?,
+            topics=?, primary_language=?, default_branch=?, archived=?, fork=?,
+            is_private=?, license_spdx=?, currently_starred=1, last_seen_at=?
+        WHERE node_id=?
+        """,
+        (
+            repo.full_name, repo.owner, repo.name, repo.url, repo.owner_type,
+            repo.description, json.dumps(repo.topics), repo.primary_language,
+            repo.default_branch, int(repo.archived), int(repo.fork),
+            int(repo.is_private), repo.license_spdx, seen_at, repo.node_id,
+        ),
+    )
+    return False
+
+
+def mark_unstarred(conn: sqlite3.Connection, node_id: str) -> None:
+    conn.execute(
+        "UPDATE external_repo SET currently_starred=0 WHERE node_id=?",
+        (node_id,),
+    )
+
+
+def list_external_repos(
+    conn: sqlite3.Connection,
+    *,
+    currently_starred: bool | None = True,
+) -> list[sqlite3.Row]:
+    if currently_starred is None:
+        return conn.execute("SELECT * FROM external_repo ORDER BY full_name").fetchall()
+    return conn.execute(
+        "SELECT * FROM external_repo WHERE currently_starred=? ORDER BY full_name",
+        (int(currently_starred),),
+    ).fetchall()
+
+
+def set_materialization_level(conn: sqlite3.Connection, node_id: str, level: str) -> None:
+    conn.execute(
+        "UPDATE external_repo SET materialization_level=? WHERE node_id=?",
+        (level, node_id),
+    )
+
+
+# --- star_event --------------------------------------------------------------
+def record_star_event(
+    conn: sqlite3.Connection,
+    *,
+    node_id: str,
+    full_name: str,
+    event: str,
+    at: str,
+    exchange_id: str = "",
+) -> None:
+    conn.execute(
+        "INSERT INTO star_event(node_id, full_name, event, at, exchange_id) "
+        "VALUES(?,?,?,?,?)",
+        (node_id, full_name, event, at, exchange_id),
+    )
+
+
+# --- exchange (spine) --------------------------------------------------------
+def seed_exchange(
+    conn: sqlite3.Connection,
+    *,
+    node_id: str,
+    full_name: str,
+    state: str = "STARRED",
+) -> str:
+    """Create the exchange spine row for a star and return its exchange_id."""
+    exchange_id = new_exchange_id()
+    ts = now_iso()
+    conn.execute(
+        "INSERT INTO exchange(exchange_id, external_repo_node_id, external_repo, "
+        "state, created_at, updated_at, data_json) VALUES(?,?,?,?,?,?, '{}')",
+        (exchange_id, node_id, full_name, state, ts, ts),
+    )
+    return exchange_id
+
+
+def exchange_for_repo(conn: sqlite3.Connection, node_id: str) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT * FROM exchange WHERE external_repo_node_id=? "
+        "ORDER BY created_at DESC LIMIT 1",
+        (node_id,),
+    ).fetchone()
+
+
+# --- snapshots / artifacts / dossiers ---------------------------------------
+def insert_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    node_id: str,
+    full_name: str,
+    ref: str,
+    pushed_at: str = "",
+    stargazers_count: int = 0,
+    open_issue_count: int = 0,
+    state_json: str = "{}",
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO repo_snapshot(node_id, full_name, ref, snapshot_at, "
+        "pushed_at, stargazers_count, open_issue_count, state_json) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        (node_id, full_name, ref, now_iso(), pushed_at, stargazers_count,
+         open_issue_count, state_json),
+    )
+    return int(cur.lastrowid)
+
+
+def insert_artifact(conn: sqlite3.Connection, node_id: str, full_name: str, art: Any) -> None:
+    conn.execute(
+        "INSERT INTO artifact(node_id, full_name, kind, name, source_url, ref, "
+        "fetched_at, sha256, bytes_len, truncated) VALUES(?,?,?,?,?,?,?,?,?,?)",
+        (node_id, full_name, art.kind, art.name, art.source_url, art.ref,
+         art.fetched_at, art.sha256, art.bytes_len, int(art.truncated)),
+    )
+
+
+def upsert_dossier(conn: sqlite3.Connection, dossier: Any, *, exchange_id: str = "") -> None:
+    import json
+
+    conn.execute(
+        """
+        INSERT INTO dossier(node_id, full_name, level, schema_version,
+            snapshot_ref, snapshot_at, doc_json, exchange_id)
+        VALUES(?,?,?,?,?,?,?,?)
+        ON CONFLICT(node_id, level) DO UPDATE SET
+            doc_json=excluded.doc_json, snapshot_ref=excluded.snapshot_ref,
+            snapshot_at=excluded.snapshot_at, exchange_id=excluded.exchange_id
+        """,
+        (
+            dossier.github_node_id, dossier.external_repo, dossier.level,
+            dossier.schema_version, dossier.snapshot_ref, dossier.snapshot_at,
+            json.dumps(dossier.to_dict()), exchange_id,
+        ),
+    )
+
+
+def get_dossier(
+    conn: sqlite3.Connection,
+    node_id: str,
+    level: str | None = None,
+) -> sqlite3.Row | None:
+    if level:
+        return conn.execute(
+            "SELECT * FROM dossier WHERE node_id=? AND level=?",
+            (node_id, level),
+        ).fetchone()
+    return conn.execute(
+        "SELECT * FROM dossier WHERE node_id=? ORDER BY level DESC LIMIT 1",
+        (node_id,),
+    ).fetchone()
+
+
+def counts(conn: sqlite3.Connection) -> dict[str, int]:
+    """Summary row counts for status reporting."""
+    out: dict[str, int] = {}
+    for table in ("external_repo", "star_event", "repo_snapshot", "artifact",
+                  "dossier", "exchange"):
+        row = conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()  # noqa: S608
+        out[table] = int(row["n"])
+    starred = conn.execute(
+        "SELECT COUNT(*) AS n FROM external_repo WHERE currently_starred=1",
+    ).fetchone()
+    out["currently_starred"] = int(starred["n"])
+    return out

--- a/src/alchemia/github/storage.py
+++ b/src/alchemia/github/storage.py
@@ -235,11 +235,23 @@ def upsert_external_repo(conn: sqlite3.Connection, repo: Any, *, seen_at: str) -
             VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1,'S0',?,?)
             """,
             (
-                repo.node_id, repo.full_name, repo.owner, repo.name, repo.url,
-                repo.owner_type, repo.description, json.dumps(repo.topics),
-                repo.primary_language, repo.default_branch, int(repo.archived),
-                int(repo.fork), int(repo.is_private), repo.license_spdx,
-                repo.starred_at, seen_at, seen_at,
+                repo.node_id,
+                repo.full_name,
+                repo.owner,
+                repo.name,
+                repo.url,
+                repo.owner_type,
+                repo.description,
+                json.dumps(repo.topics),
+                repo.primary_language,
+                repo.default_branch,
+                int(repo.archived),
+                int(repo.fork),
+                int(repo.is_private),
+                repo.license_spdx,
+                repo.starred_at,
+                seen_at,
+                seen_at,
             ),
         )
         return True
@@ -252,10 +264,21 @@ def upsert_external_repo(conn: sqlite3.Connection, repo: Any, *, seen_at: str) -
         WHERE node_id=?
         """,
         (
-            repo.full_name, repo.owner, repo.name, repo.url, repo.owner_type,
-            repo.description, json.dumps(repo.topics), repo.primary_language,
-            repo.default_branch, int(repo.archived), int(repo.fork),
-            int(repo.is_private), repo.license_spdx, seen_at, repo.node_id,
+            repo.full_name,
+            repo.owner,
+            repo.name,
+            repo.url,
+            repo.owner_type,
+            repo.description,
+            json.dumps(repo.topics),
+            repo.primary_language,
+            repo.default_branch,
+            int(repo.archived),
+            int(repo.fork),
+            int(repo.is_private),
+            repo.license_spdx,
+            seen_at,
+            repo.node_id,
         ),
     )
     return False
@@ -299,8 +322,7 @@ def record_star_event(
     exchange_id: str = "",
 ) -> None:
     conn.execute(
-        "INSERT INTO star_event(node_id, full_name, event, at, exchange_id) "
-        "VALUES(?,?,?,?,?)",
+        "INSERT INTO star_event(node_id, full_name, event, at, exchange_id) VALUES(?,?,?,?,?)",
         (node_id, full_name, event, at, exchange_id),
     )
 
@@ -326,8 +348,7 @@ def seed_exchange(
 
 def exchange_for_repo(conn: sqlite3.Connection, node_id: str) -> sqlite3.Row | None:
     return conn.execute(
-        "SELECT * FROM exchange WHERE external_repo_node_id=? "
-        "ORDER BY created_at DESC LIMIT 1",
+        "SELECT * FROM exchange WHERE external_repo_node_id=? ORDER BY created_at DESC LIMIT 1",
         (node_id,),
     ).fetchone()
 
@@ -348,8 +369,16 @@ def insert_snapshot(
         "INSERT INTO repo_snapshot(node_id, full_name, ref, snapshot_at, "
         "pushed_at, stargazers_count, open_issue_count, state_json) "
         "VALUES(?,?,?,?,?,?,?,?)",
-        (node_id, full_name, ref, now_iso(), pushed_at, stargazers_count,
-         open_issue_count, state_json),
+        (
+            node_id,
+            full_name,
+            ref,
+            now_iso(),
+            pushed_at,
+            stargazers_count,
+            open_issue_count,
+            state_json,
+        ),
     )
     return int(cur.lastrowid or 0)
 
@@ -358,8 +387,18 @@ def insert_artifact(conn: sqlite3.Connection, node_id: str, full_name: str, art:
     conn.execute(
         "INSERT INTO artifact(node_id, full_name, kind, name, source_url, ref, "
         "fetched_at, sha256, bytes_len, truncated) VALUES(?,?,?,?,?,?,?,?,?,?)",
-        (node_id, full_name, art.kind, art.name, art.source_url, art.ref,
-         art.fetched_at, art.sha256, art.bytes_len, int(art.truncated)),
+        (
+            node_id,
+            full_name,
+            art.kind,
+            art.name,
+            art.source_url,
+            art.ref,
+            art.fetched_at,
+            art.sha256,
+            art.bytes_len,
+            int(art.truncated),
+        ),
     )
 
 
@@ -376,9 +415,14 @@ def upsert_dossier(conn: sqlite3.Connection, dossier: Any, *, exchange_id: str =
             snapshot_at=excluded.snapshot_at, exchange_id=excluded.exchange_id
         """,
         (
-            dossier.github_node_id, dossier.external_repo, dossier.level,
-            dossier.schema_version, dossier.snapshot_ref, dossier.snapshot_at,
-            json.dumps(dossier.to_dict()), exchange_id,
+            dossier.github_node_id,
+            dossier.external_repo,
+            dossier.level,
+            dossier.schema_version,
+            dossier.snapshot_ref,
+            dossier.snapshot_at,
+            json.dumps(dossier.to_dict()),
+            exchange_id,
         ),
     )
 
@@ -402,8 +446,14 @@ def get_dossier(
 def counts(conn: sqlite3.Connection) -> dict[str, int]:
     """Summary row counts for status reporting."""
     out: dict[str, int] = {}
-    for table in ("external_repo", "star_event", "repo_snapshot", "artifact",
-                  "dossier", "exchange"):
+    for table in (
+        "external_repo",
+        "star_event",
+        "repo_snapshot",
+        "artifact",
+        "dossier",
+        "exchange",
+    ):
         row = conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()  # noqa: S608
         out[table] = int(row["n"])
     starred = conn.execute(

--- a/src/alchemia/github/sync.py
+++ b/src/alchemia/github/sync.py
@@ -1,0 +1,122 @@
+"""Incremental star synchronization for BIFRONS.
+
+Enumerates the authenticated user's starred repositories and reconciles them
+against the portal store: new stars are inserted (and their exchange spine is
+seeded), returning stars are refreshed, and repositories that are no longer
+starred are marked ``currently_starred = 0`` with an ``unstar`` event.
+
+Re-running a sync with no upstream change makes no row changes (idempotent).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from alchemia.github import storage
+from alchemia.github.client import STAR_ACCEPT, authenticated_login, gh_api_paginated
+from alchemia.github.models import StarredRepo
+
+
+@dataclass
+class SyncSummary:
+    total: int = 0
+    new: int = 0
+    refreshed: int = 0
+    unstarred: int = 0
+    login: str = ""
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {
+            "total": self.total,
+            "new": self.new,
+            "refreshed": self.refreshed,
+            "unstarred": self.unstarred,
+            "login": self.login,
+        }
+
+
+def enumerate_stars() -> list[StarredRepo]:
+    """Return every starred repository for the authenticated user.
+
+    Uses the star media type so each element carries ``starred_at``.
+    """
+    raw = gh_api_paginated("user/starred", accept=STAR_ACCEPT)
+    return [StarredRepo.from_star_json(obj) for obj in raw]
+
+
+def sync_stars(
+    conn: sqlite3.Connection,
+    *,
+    stars: Iterable[StarredRepo] | None = None,
+    login: str | None = None,
+) -> SyncSummary:
+    """Reconcile the portal store against the current star set.
+
+    ``stars``/``login`` may be injected (for tests / offline runs); otherwise
+    they are fetched live via gh.
+    """
+    storage.init_intake_schema(conn)
+    star_list = list(stars) if stars is not None else enumerate_stars()
+    who = login if login is not None else _safe_login()
+
+    seen_at = storage.now_iso()
+    summary = SyncSummary(total=len(star_list), login=who)
+
+    live_node_ids: set[str] = set()
+    for repo in star_list:
+        if not repo.node_id:
+            continue
+        live_node_ids.add(repo.node_id)
+        existing = storage.get_external_repo(conn, repo.node_id)
+        was_unstarred = existing is not None and existing["currently_starred"] == 0
+        is_new = storage.upsert_external_repo(conn, repo, seen_at=seen_at)
+        if is_new:
+            exchange_id = storage.seed_exchange(
+                conn, node_id=repo.node_id, full_name=repo.full_name, state="STARRED",
+            )
+            storage.record_star_event(
+                conn, node_id=repo.node_id, full_name=repo.full_name,
+                event="star", at=repo.starred_at or seen_at, exchange_id=exchange_id,
+            )
+            summary.new += 1
+        elif was_unstarred:
+            # Re-star: record the event and reattach (or seed) an exchange spine.
+            exchange = storage.exchange_for_repo(conn, repo.node_id)
+            exchange_id = (
+                exchange["exchange_id"] if exchange
+                else storage.seed_exchange(
+                    conn, node_id=repo.node_id, full_name=repo.full_name, state="STARRED",
+                )
+            )
+            storage.record_star_event(
+                conn, node_id=repo.node_id, full_name=repo.full_name,
+                event="star", at=seen_at, exchange_id=exchange_id,
+            )
+            summary.refreshed += 1
+        else:
+            summary.refreshed += 1
+
+    # Detect unstars: repos previously starred but absent from the live set.
+    for row in storage.list_external_repos(conn, currently_starred=True):
+        if row["node_id"] not in live_node_ids:
+            storage.mark_unstarred(conn, row["node_id"])
+            storage.record_star_event(
+                conn, node_id=row["node_id"], full_name=row["full_name"],
+                event="unstar", at=seen_at,
+            )
+            summary.unstarred += 1
+
+    storage.set_meta(conn, "last_sync", seen_at)
+    if who:
+        storage.set_meta(conn, "gh_login", who)
+    conn.commit()
+    return summary
+
+
+def _safe_login() -> str:
+    try:
+        return authenticated_login()
+    except Exception:  # noqa: BLE001 - login is best-effort metadata
+        return ""

--- a/src/alchemia/github/sync.py
+++ b/src/alchemia/github/sync.py
@@ -74,25 +74,40 @@ def sync_stars(
         is_new = storage.upsert_external_repo(conn, repo, seen_at=seen_at)
         if is_new:
             exchange_id = storage.seed_exchange(
-                conn, node_id=repo.node_id, full_name=repo.full_name, state="STARRED",
+                conn,
+                node_id=repo.node_id,
+                full_name=repo.full_name,
+                state="STARRED",
             )
             storage.record_star_event(
-                conn, node_id=repo.node_id, full_name=repo.full_name,
-                event="star", at=repo.starred_at or seen_at, exchange_id=exchange_id,
+                conn,
+                node_id=repo.node_id,
+                full_name=repo.full_name,
+                event="star",
+                at=repo.starred_at or seen_at,
+                exchange_id=exchange_id,
             )
             summary.new += 1
         elif was_unstarred:
             # Re-star: record the event and reattach (or seed) an exchange spine.
             exchange = storage.exchange_for_repo(conn, repo.node_id)
             exchange_id = (
-                exchange["exchange_id"] if exchange
+                exchange["exchange_id"]
+                if exchange
                 else storage.seed_exchange(
-                    conn, node_id=repo.node_id, full_name=repo.full_name, state="STARRED",
+                    conn,
+                    node_id=repo.node_id,
+                    full_name=repo.full_name,
+                    state="STARRED",
                 )
             )
             storage.record_star_event(
-                conn, node_id=repo.node_id, full_name=repo.full_name,
-                event="star", at=seen_at, exchange_id=exchange_id,
+                conn,
+                node_id=repo.node_id,
+                full_name=repo.full_name,
+                event="star",
+                at=seen_at,
+                exchange_id=exchange_id,
             )
             summary.refreshed += 1
         else:
@@ -103,8 +118,11 @@ def sync_stars(
         if row["node_id"] not in live_node_ids:
             storage.mark_unstarred(conn, row["node_id"])
             storage.record_star_event(
-                conn, node_id=row["node_id"], full_name=row["full_name"],
-                event="unstar", at=seen_at,
+                conn,
+                node_id=row["node_id"],
+                full_name=row["full_name"],
+                event="unstar",
+                at=seen_at,
             )
             summary.unstarred += 1
 

--- a/tests/test_github_dossier.py
+++ b/tests/test_github_dossier.py
@@ -1,0 +1,104 @@
+"""Epic 2 — dossier generation (metadata-first, pinned, hashed)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from alchemia.github import dossier as dossier_mod
+from alchemia.github import licensing as licensing_mod
+from alchemia.github.client import GitHubError
+from alchemia.github.models import StarredRepo
+
+FAKE_SHA = "abc123def4567890abc123def4567890abc12345"
+PRESENT = {"README.md", "pyproject.toml", "CONTRIBUTING.md"}
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode()).decode()
+
+
+def fake_gh_api(path: str, *, accept=None, jq=None):
+    """Route a small deterministic GitHub API surface for tests."""
+    if path.startswith("repos/") and "/commits/" in path and jq == ".sha":
+        return FAKE_SHA
+    if path.endswith("/license") and jq == ".license.spdx_id":
+        return "MIT"
+    if path.endswith("/languages"):
+        return {"Python": 800, "Shell": 200}
+    if "/git/trees/" in path:
+        return {"tree": [
+            {"path": "src/pkg/__init__.py", "type": "blob"},
+            {"path": "src/pkg/core.py", "type": "blob"},
+            {"path": "tests/test_core.py", "type": "blob"},
+            {"path": "README.md", "type": "blob"},
+        ]}
+    if "/contents/" in path:
+        # strip ?ref=
+        rel = path.split("/contents/", 1)[1].split("?", 1)[0]
+        if jq == ".sha":
+            if rel in PRESENT:
+                return "sha-" + rel
+            raise GitHubError("404")
+        if jq == ".content":
+            return _b64("Please add a Signed-off-by line (DCO).")
+        # full object fetch
+        if rel in PRESENT:
+            return {
+                "type": "file",
+                "content": _b64(f"# contents of {rel}\n"),
+                "html_url": f"https://github.com/x/y/blob/main/{rel}",
+                "size": 20,
+            }
+        raise GitHubError("404")
+    raise GitHubError(f"unexpected path {path}")
+
+
+@pytest.fixture(autouse=True)
+def _patch_gh(monkeypatch):
+    monkeypatch.setattr(dossier_mod, "gh_api", fake_gh_api)
+    monkeypatch.setattr(licensing_mod, "gh_api", fake_gh_api)
+
+
+def _repo() -> StarredRepo:
+    return StarredRepo(
+        full_name="astral-sh/ruff",
+        node_id="R_kg1",
+        owner="astral-sh",
+        name="ruff",
+        url="https://github.com/astral-sh/ruff",
+        starred_at="2026-06-01T00:00:00Z",
+        primary_language="Rust",
+        license_spdx="MIT",
+        default_branch="main",
+    )
+
+
+def test_build_dossier_pins_ref_and_hashes_artifacts():
+    dossier, artifacts = dossier_mod.build_dossier(_repo())
+    assert dossier.snapshot_ref == FAKE_SHA
+    assert dossier.schema_version == "1.0"
+    assert dossier.level == "S1"
+    # README + CONTRIBUTING fetched; every artifact carries a sha256.
+    names = {a.name for a in artifacts}
+    assert "README.md" in names
+    assert all(a.sha256 for a in artifacts)
+    # Provenance links artifact -> hash.
+    assert dossier.provenance["hashes"]["README.md"]
+
+
+def test_dossier_detects_license_and_contracts():
+    dossier, _ = dossier_mod.build_dossier(_repo())
+    assert dossier.contracts["license"]["spdx"] == "MIT"
+    assert dossier.contracts["license"]["class"] == "permissive"
+    assert dossier.contracts["decision"] == "code-adaptation-with-attribution"
+    assert dossier.contracts["contributing"] == "CONTRIBUTING.md"
+    assert dossier.contracts["cla_or_dco"] == "dco"
+
+
+def test_dossier_architecture_manifests():
+    dossier, _ = dossier_mod.build_dossier(_repo())
+    assert "pyproject.toml" in dossier.architecture["manifests"]
+    assert "python" in dossier.architecture["test_strategy"]
+    assert dossier.identity["languages"]["Python"] == 0.8

--- a/tests/test_github_dossier.py
+++ b/tests/test_github_dossier.py
@@ -28,12 +28,14 @@ def fake_gh_api(path: str, *, accept=None, jq=None):
     if path.endswith("/languages"):
         return {"Python": 800, "Shell": 200}
     if "/git/trees/" in path:
-        return {"tree": [
-            {"path": "src/pkg/__init__.py", "type": "blob"},
-            {"path": "src/pkg/core.py", "type": "blob"},
-            {"path": "tests/test_core.py", "type": "blob"},
-            {"path": "README.md", "type": "blob"},
-        ]}
+        return {
+            "tree": [
+                {"path": "src/pkg/__init__.py", "type": "blob"},
+                {"path": "src/pkg/core.py", "type": "blob"},
+                {"path": "tests/test_core.py", "type": "blob"},
+                {"path": "README.md", "type": "blob"},
+            ],
+        }
     if "/contents/" in path:
         # strip ?ref=
         rel = path.split("/contents/", 1)[1].split("?", 1)[0]

--- a/tests/test_github_licensing.py
+++ b/tests/test_github_licensing.py
@@ -1,0 +1,34 @@
+"""License firewall classification — the permitted-behavior tiers."""
+
+from __future__ import annotations
+
+import pytest
+
+from alchemia.github.licensing import classify_license, license_decision
+
+
+@pytest.mark.parametrize(
+    ("spdx", "expected"),
+    [
+        ("MIT", "permissive"),
+        ("Apache-2.0", "permissive"),
+        ("BSD-3-Clause", "permissive"),
+        ("ISC", "permissive"),
+        ("GPL-3.0", "copyleft"),
+        ("AGPL-3.0", "copyleft"),
+        ("MPL-2.0", "copyleft"),
+        ("LGPL-2.1", "copyleft"),
+        ("", "unknown"),
+        ("NOASSERTION", "none"),
+        ("SOME-WEIRD-LICENSE", "unknown"),
+    ],
+)
+def test_classify_license(spdx, expected):
+    assert classify_license(spdx) == expected
+
+
+def test_license_decision_firewall():
+    assert license_decision("permissive") == "code-adaptation-with-attribution"
+    assert license_decision("copyleft").startswith("idea-or-interface-only")
+    assert license_decision("none") == "no-code-or-asset-copying"
+    assert license_decision("unknown") == "no-code-or-asset-copying"

--- a/tests/test_github_materialization.py
+++ b/tests/test_github_materialization.py
@@ -30,9 +30,15 @@ def db(tmp_path):
 
 def _seed(db, *, private=False):
     repo = StarredRepo(
-        full_name="astral-sh/ruff", node_id="R_kg1", owner="astral-sh", name="ruff",
-        url="https://github.com/astral-sh/ruff", starred_at="2026-06-01T00:00:00Z",
-        primary_language="Rust", license_spdx="MIT", default_branch="main",
+        full_name="astral-sh/ruff",
+        node_id="R_kg1",
+        owner="astral-sh",
+        name="ruff",
+        url="https://github.com/astral-sh/ruff",
+        starred_at="2026-06-01T00:00:00Z",
+        primary_language="Rust",
+        license_spdx="MIT",
+        default_branch="main",
         is_private=private,
     )
     sync_stars(db, stars=[repo], login="t")

--- a/tests/test_github_materialization.py
+++ b/tests/test_github_materialization.py
@@ -1,0 +1,93 @@
+"""Materialization levels — S0/S1/S2 persist; S3 defers; private stays local."""
+
+from __future__ import annotations
+
+import pytest
+
+from alchemia.github import dossier as dossier_mod
+from alchemia.github import licensing as licensing_mod
+from alchemia.github import materialize as mat_mod
+from alchemia.github import storage
+from alchemia.github.materialize import materialize
+from alchemia.github.models import MaterializationLevel, StarredRepo
+from alchemia.github.sync import sync_stars
+from tests.test_github_dossier import fake_gh_api
+
+
+@pytest.fixture(autouse=True)
+def _patch_gh(monkeypatch):
+    monkeypatch.setattr(dossier_mod, "gh_api", fake_gh_api)
+    monkeypatch.setattr(licensing_mod, "gh_api", fake_gh_api)
+    monkeypatch.setattr(mat_mod, "gh_api", fake_gh_api)
+
+
+@pytest.fixture
+def db(tmp_path):
+    conn = storage.connect(tmp_path / "portal.db")
+    yield conn
+    conn.close()
+
+
+def _seed(db, *, private=False):
+    repo = StarredRepo(
+        full_name="astral-sh/ruff", node_id="R_kg1", owner="astral-sh", name="ruff",
+        url="https://github.com/astral-sh/ruff", starred_at="2026-06-01T00:00:00Z",
+        primary_language="Rust", license_spdx="MIT", default_branch="main",
+        is_private=private,
+    )
+    sync_stars(db, stars=[repo], login="t")
+    return repo
+
+
+def test_materialize_dossier_persists_and_advances_level(db):
+    _seed(db)
+    result = materialize(db, "R_kg1", MaterializationLevel.DOSSIER)
+    assert result["status"] == "materialized"
+    assert result["level"] == "S1"
+    row = storage.get_external_repo(db, "R_kg1")
+    assert row["materialization_level"] == "S1"
+    # Dossier + snapshot + artifacts landed in the store.
+    counts = storage.counts(db)
+    assert counts["dossier"] == 1
+    assert counts["repo_snapshot"] == 1
+    assert counts["artifact"] >= 1
+    # The dossier is linked to the star's exchange spine.
+    doss = storage.get_dossier(db, "R_kg1", "S1")
+    ex = storage.exchange_for_repo(db, "R_kg1")
+    assert doss["exchange_id"] == ex["exchange_id"]
+
+
+def test_materialize_inspect_records_tree(db):
+    _seed(db)
+    result = materialize(db, "R_kg1", MaterializationLevel.INSPECT)
+    assert result["level"] == "S2"
+    assert result["tree_entries"] == 4
+    assert "src" in result["notable_modules"]
+
+
+def test_materialize_dossier_is_idempotent(db):
+    _seed(db)
+    materialize(db, "R_kg1", MaterializationLevel.DOSSIER)
+    materialize(db, "R_kg1", MaterializationLevel.DOSSIER)
+    # UNIQUE(node_id, level) keeps exactly one dossier row.
+    assert storage.counts(db)["dossier"] == 1
+
+
+def test_private_repo_is_not_deep_materialized(db):
+    _seed(db, private=True)
+    result = materialize(db, "R_kg1", MaterializationLevel.DOSSIER)
+    assert result["status"] == "private-skip"
+    assert storage.counts(db)["dossier"] == 0
+
+
+def test_contribute_level_defers_to_engine(db):
+    _seed(db)
+    result = materialize(db, "R_kg1", MaterializationLevel.CONTRIBUTE)
+    assert result["status"] == "deferred-to-engine"
+    assert result["level"] == "S3"
+
+
+def test_unknown_repo(db):
+    storage.init_intake_schema(db)
+    result = materialize(db, "R_nope", MaterializationLevel.DOSSIER)
+    assert result["status"] == "unknown-repo"

--- a/tests/test_github_stars.py
+++ b/tests/test_github_stars.py
@@ -1,0 +1,113 @@
+"""Epic 1 — star corpus sync: coverage, idempotency, star/unstar history."""
+
+from __future__ import annotations
+
+import pytest
+
+from alchemia.github import storage
+from alchemia.github.models import StarredRepo
+from alchemia.github.sync import sync_stars
+
+
+def _repo(node_id: str, full_name: str, **kw) -> StarredRepo:
+    owner, name = full_name.split("/")
+    return StarredRepo(
+        full_name=full_name,
+        node_id=node_id,
+        owner=owner,
+        name=name,
+        url=f"https://github.com/{full_name}",
+        starred_at=kw.get("starred_at", "2026-07-01T00:00:00Z"),
+        primary_language=kw.get("primary_language", "Python"),
+        license_spdx=kw.get("license_spdx", "MIT"),
+    )
+
+
+@pytest.fixture
+def db(tmp_path):
+    conn = storage.connect(tmp_path / "portal.db")
+    yield conn
+    conn.close()
+
+
+def test_star_json_parsing_with_media_type():
+    obj = {
+        "starred_at": "2026-06-15T12:00:00Z",
+        "repo": {
+            "full_name": "astral-sh/ruff",
+            "node_id": "R_kg123",
+            "name": "ruff",
+            "owner": {"login": "astral-sh", "type": "Organization"},
+            "html_url": "https://github.com/astral-sh/ruff",
+            "description": "An extremely fast Python linter",
+            "topics": ["python", "linter"],
+            "language": "Rust",
+            "default_branch": "main",
+            "license": {"spdx_id": "MIT"},
+            "stargazers_count": 30000,
+        },
+    }
+    repo = StarredRepo.from_star_json(obj)
+    assert repo.full_name == "astral-sh/ruff"
+    assert repo.starred_at == "2026-06-15T12:00:00Z"
+    assert repo.owner_type == "Organization"
+    assert repo.license_spdx == "MIT"
+    assert repo.topics == ["python", "linter"]
+
+
+def test_sync_inserts_and_seeds_exchange(db):
+    stars = [_repo("R_1", "a/one"), _repo("R_2", "b/two")]
+    summary = sync_stars(db, stars=stars, login="tester")
+    assert summary.total == 2
+    assert summary.new == 2
+    assert summary.unstarred == 0
+    counts = storage.counts(db)
+    assert counts["external_repo"] == 2
+    assert counts["currently_starred"] == 2
+    # Every new star seeds an exchange spine row + a star event.
+    assert counts["exchange"] == 2
+    assert counts["star_event"] == 2
+
+
+def test_sync_is_idempotent(db):
+    stars = [_repo("R_1", "a/one"), _repo("R_2", "b/two")]
+    sync_stars(db, stars=stars, login="tester")
+    second = sync_stars(db, stars=stars, login="tester")
+    assert second.new == 0
+    assert second.refreshed == 2
+    assert second.unstarred == 0
+    counts = storage.counts(db)
+    # Re-running creates no duplicate repos, exchanges, or events.
+    assert counts["external_repo"] == 2
+    assert counts["exchange"] == 2
+    assert counts["star_event"] == 2
+
+
+def test_sync_detects_unstar(db):
+    sync_stars(db, stars=[_repo("R_1", "a/one"), _repo("R_2", "b/two")], login="t")
+    # Second sync: R_2 no longer starred.
+    summary = sync_stars(db, stars=[_repo("R_1", "a/one")], login="t")
+    assert summary.unstarred == 1
+    counts = storage.counts(db)
+    assert counts["currently_starred"] == 1
+    # Unstar is recorded as history, not deleted.
+    assert counts["external_repo"] == 2
+    events = db.execute(
+        "SELECT event FROM star_event WHERE full_name='b/two' ORDER BY id",
+    ).fetchall()
+    assert [e["event"] for e in events] == ["star", "unstar"]
+
+
+def test_restar_after_unstar(db):
+    sync_stars(db, stars=[_repo("R_1", "a/one")], login="t")
+    sync_stars(db, stars=[], login="t")  # unstar
+    sync_stars(db, stars=[_repo("R_1", "a/one")], login="t")  # restar
+    row = storage.get_external_repo(db, "R_1")
+    assert row["currently_starred"] == 1
+    counts = storage.counts(db)
+    assert counts["currently_starred"] == 1
+    # Full history retained: star -> unstar -> star.
+    events = db.execute(
+        "SELECT event FROM star_event WHERE node_id='R_1' ORDER BY id",
+    ).fetchall()
+    assert [e["event"] for e in events] == ["star", "unstar", "star"]


### PR DESCRIPTION
## BIFRONS — inbound star intake (Epics 1–2)

The inbound half of the **BIFRONS** star↔contribution portal (Janus, two-faced — distinct from IANVA, the MCP doorway). Absorbs the GitHub star corpus into provenance-backed dossiers in a shared portal store the organvm-engine network/portal/contrib subsystems read downstream.

### What's here
- `channels/github_stars.py` — enumerate stars via `gh` (star media type → `starred_at` retained)
- `github/client.py` — read-only authenticated gh adapter (never clones, never executes starred code)
- `github/models.py` — `StarredRepo`/`Dossier`/`Artifact`, S0–S3 materialization levels
- `github/storage.py` — `portal.db` (SQLite+WAL) schema owner + the **exchange spine** (one row per star traversal)
- `github/sync.py` — incremental star/unstar reconciliation (idempotent)
- `github/licensing.py` — license firewall + contribution-contract discovery
- `github/dossier.py` — pinned-to-commit, hashed, metadata-first dossiers
- `github/materialize.py` — S0–S3 (S3 deferred to engine; private repos stay local)
- CLI: `alchemia stars sync|status|dossier|materialize`

Store: `~/.organvm/bifrons/portal.db` (override `$BIFRONS_DB`).

### Verified
- **Real sync of 419 live stars**; idempotent re-run (new=0, refreshed=419)
- **Real S1 dossier via gh** — pinned ref + hashed artifacts + license decision, linked to the exchange spine
- 26 new tests; full suite **178 passing**; ruff clean

Part of the cross-repo BIFRONS build (ontologia + engine PRs follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)