### PR TITLE
fix(stale): never auto-close — label only (days-before-close: -1)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,14 +17,12 @@ jobs:
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not
-            had recent activity. It will be closed in 14 days if no further
-            activity occurs.
+            had recent activity. It will remain open — this label is informational only; this project never auto-closes.
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not
-            had recent activity. It will be closed in 14 days if no further
-            activity occurs.
+            had recent activity. It will remain open — this label is informational only; this project never auto-closes.
           days-before-stale: 60
-          days-before-close: 14
+          days-before-close: -1
           exempt-issue-labels: 'pinned,evergreen,omega,blocked'
           exempt-pr-labels: 'pinned,evergreen,work-in-progress'
           stale-issue-label: 'stale'


### PR DESCRIPTION
The stale workflow auto-closed issues/PRs, violating this universe's absolute doctrine: **we never close, dismiss, or delete** — *if it was ever asked for it was wanted*.

This sets the close window to `-1` (`actions/stale` never-close), preserving the informational `stale` label but never closing. Surgical, reversible, single-file.